### PR TITLE
Remove println!() in get_version()

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -452,7 +452,6 @@ impl I3Connection {
             Ok((_, payload)) => payload,
             Err(e) => { return Err(MessageError::Receive(e)); }
         };
-        println!("{}", payload);
         let j = match json::from_str::<json::Value>(&payload) {
             Ok(v) => v,
             Err(e) => { return Err(MessageError::JsonCouldntParse(e)); }


### PR DESCRIPTION
I believe it serves no purpose other than cluttering the stdout
