### PR TITLE
Add WindowChange::Mark to handle upstream i3 IPC change

### DIFF
--- a/src/event.rs
+++ b/src/event.rs
@@ -121,6 +121,7 @@ impl FromStr for WindowEventInfo {
                 "move" => WindowChange::Move,
                 "floating" => WindowChange::Floating,
                 "urgent" => WindowChange::Urgent,
+                "mark" => WindowChange::Mark,
                 _ => unreachable!()
             },
             container: common::build_tree(val.find("container").unwrap())
@@ -223,7 +224,9 @@ pub mod inner {
         /// The window has transitioned to or from floating.
         Floating,
         /// The window has become urgent or lost its urgent status.
-        Urgent
+        Urgent,
+        /// The window's marks have been modified
+        Mark
     }
 
     /// Either keyboard or mouse.


### PR DESCRIPTION
this was added to i3 with https://github.com/i3/i3/commit/e51a89e84259e854756a20f6367299eee1612da9