### PR TITLE
Add primary flag to Output struct

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -367,6 +367,7 @@ impl I3Connection {
                            reply::Output {
                                name: o.find("name").unwrap().as_string().unwrap().to_owned(),
                                active: o.find("active").unwrap().as_boolean().unwrap(),
+                               primary: o.find("primary").unwrap().as_boolean().unwrap(),
                                current_workspace: match o.find("current_workspace").unwrap().clone() {
                                    json::Value::String(c_w) => Some(c_w),
                                    json::Value::Null => None,

--- a/src/reply.rs
+++ b/src/reply.rs
@@ -63,6 +63,8 @@ pub struct Output {
     pub name: String,
     /// Whether the output is currently active (has a valid mode).
     pub active: bool,
+    /// Whether the output is currently the primary output.
+    pub primary: bool,
     /// The name of the current workspace that is visible on this output. None if the output is
     /// not active.
     pub current_workspace: Option<String>,


### PR DESCRIPTION
The primary flag indicates whether the output is currently considered
the primary output by the X server.