### PR TITLE
Use i64 for container ids

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -14,7 +14,7 @@ pub fn build_tree(val: &json::Value) -> reply::Node {
                             .collect::<Vec<_>>(),
             None => vec![]
         },
-        id: val.find("id").unwrap().as_i64().unwrap() as i32,
+        id: val.find("id").unwrap().as_i64().unwrap(),
         name: match val.find("name") {
             Some(n) => match n.as_string() {
                 Some(s) => Some(s.to_owned()),

--- a/src/reply.rs
+++ b/src/reply.rs
@@ -122,7 +122,7 @@ pub struct Node {
     /// The internal ID (actually a C pointer value) of this container. Do not make any
     /// assumptions about it. You can use it to (re-)identify and address containers when
     /// talking to i3.
-    pub id: i32,
+    pub id: i64,
 
     /// The internal name of this container. For all containers which are part of the tree
     /// structure down to the workspace contents, this is set to a nice human-readable name of


### PR DESCRIPTION
Since container IDs are a C pointer value, on 64-bit operating systems they can overflow i32.

For example, on my current instance:
```
> i3-msg -t get_tree | jq .| grep '"id"'
"id": 93833137164352,
      "id": 93833137164816,
          "id": 93833137167344,
              "id": 93833137167840,
      "id": 93833137176192,
          "id": 93833137176768,
              "id": 93833137384176,
          "id": 93833137180048,
              "id": 93833137180512,
                  "id": 93833137181104,
          "id": 93833137189616,
      "id": 93833137195472,
          "id": 93833137195968,
              "id": 93833137410608,
          "id": 93833137199264,
              "id": 93833137199728,
                  "id": 93833137200320,
              "id": 93833137206256,
                  "id": 93833137206816,
                      "id": 93833137207280,
              "id": 93833137215824,
                  "id": 93833137216384,
                      "id": 93833137216848,
                      "id": 93833137220176,
                      "id": 93833137223504,
                      "id": 93833137444240,
                      "id": 93833137226736,
          "id": 93833137237936,
```