### PR TITLE
support floating_nodes in TREE reply

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -14,6 +14,14 @@ pub fn build_tree(val: &json::Value) -> reply::Node {
                             .collect::<Vec<_>>(),
             None => vec![]
         },
+        floating_nodes: match val.find("floating_nodes") {
+            Some(nds) => nds.as_array()
+                            .unwrap()
+                            .iter()
+                            .map(|n| build_tree(n))
+                            .collect::<Vec<_>>(),
+            None => vec![]
+        },
         id: val.find("id").unwrap().as_i64().unwrap(),
         name: match val.find("name") {
             Some(n) => match n.as_string() {

--- a/src/reply.rs
+++ b/src/reply.rs
@@ -119,6 +119,9 @@ pub struct Node {
     /// The child nodes of this container.
     pub nodes: Vec<Node>,
 
+    /// The child floating nodes of this container.
+    pub floating_nodes: Vec<Node>,
+
     /// The internal ID (actually a C pointer value) of this container. Do not make any
     /// assumptions about it. You can use it to (re-)identify and address containers when
     /// talking to i3.


### PR DESCRIPTION
Adds in `floating_nodes` when calling `get_tree()`.
Also gets used in the workspace event, but like `nodes` it will simply be empty.