### PR TITLE
get_socket_path(): try to fetch from env first

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,7 @@ extern crate log;
 extern crate serde;
 extern crate serde_json;
 
-use std::{io, fmt, process};
+use std::{env, io, fmt, process};
 use std::io::prelude::*;
 use std::error::Error;
 use std::str::FromStr;
@@ -105,6 +105,10 @@ impl fmt::Display for MessageError {
 }
 
 fn get_socket_path() -> io::Result<String> {
+    if let Ok(sockpath) = env::var("I3SOCK") {
+        return Ok(sockpath);
+    }
+
     let output = try!(process::Command::new("i3")
                                        .arg("--get-socketpath")
                                        .output());


### PR DESCRIPTION
As done in i3ipc-python.

With this modification, the library can also be used with [sway](https://github.com/swaywm/sway).