### PR TITLE
Resolve warnings from clippy

### DIFF
--- a/examples/command_loop.rs
+++ b/examples/command_loop.rs
@@ -6,7 +6,7 @@ use i3ipc::I3Connection;
 
 fn main() {
     println!("Executes i3 commands in a loop. Enter \"q\" at any time to quit.");
-    let mut connection = I3Connection::connect().ok().expect("failed to connect");
+    let mut connection = I3Connection::connect().expect("failed to connect");
     let stdin = io::stdin();
     let mut stdout = io::stdout();
     loop {
@@ -20,7 +20,7 @@ fn main() {
         }
 
         let outcomes = connection.run_command(&command_text)
-                                 .ok().expect("failed to send command")
+                                 .expect("failed to send command")
                                  .outcomes;
         for outcome in outcomes {
             if outcome.success {

--- a/examples/event_printer.rs
+++ b/examples/event_printer.rs
@@ -7,11 +7,11 @@ use i3ipc::I3EventListener;
 use i3ipc::Subscription;
 
 fn main() {
-    let mut listener = I3EventListener::connect().ok().expect("failed to connect");
+    let mut listener = I3EventListener::connect().expect("failed to connect");
     let subs = [Subscription::Workspace, Subscription::Output, Subscription::Mode,
                 Subscription::Window, Subscription::BarConfig, Subscription::Binding];
-    listener.subscribe(&subs).ok().expect("failed to subscribe");
+    listener.subscribe(&subs).expect("failed to subscribe");
     for event in listener.listen() {
-        println!("{:?}\n", event.ok().expect("failed to get event"))
+        println!("{:?}\n", event.expect("failed to get event"))
     }
 }

--- a/examples/hovered_window.rs
+++ b/examples/hovered_window.rs
@@ -7,8 +7,8 @@ use i3ipc::Subscription;
 use i3ipc::event::Event;
 
 fn main() {
-    let mut listener = I3EventListener::connect().ok().expect("failed to connect");
-    listener.subscribe(&[Subscription::Window]).ok().expect("failed to subscribe");
+    let mut listener = I3EventListener::connect().expect("failed to connect");
+    listener.subscribe(&[Subscription::Window]).expect("failed to subscribe");
     for event in listener.listen() {
         match event {
             Ok(Event::WindowEvent(w)) => println!("{}", w.container.name.unwrap_or("unnamed".to_owned())),

--- a/src/common.rs
+++ b/src/common.rs
@@ -38,7 +38,7 @@ pub fn build_tree(val: &json::Value) -> reply::Node {
             },
             None => None
         },
-        nodetype: match val.get("type").unwrap().as_str().unwrap().as_ref() {
+        nodetype: match val.get("type").unwrap().as_str().unwrap() {
             "root" => reply::NodeType::Root,
             "output" => reply::NodeType::Output,
             "con" => reply::NodeType::Con,
@@ -50,7 +50,7 @@ pub fn build_tree(val: &json::Value) -> reply::Node {
                 reply::NodeType::Unknown
             }
         },
-        border: match val.get("border").unwrap().as_str().unwrap().as_ref() {
+        border: match val.get("border").unwrap().as_str().unwrap() {
             "normal" => reply::NodeBorder::Normal,
             "none" => reply::NodeBorder::None,
             "pixel" => reply::NodeBorder::Pixel,
@@ -60,7 +60,7 @@ pub fn build_tree(val: &json::Value) -> reply::Node {
             }
         },
         current_border_width: val.get("current_border_width").unwrap().as_i64().unwrap() as i32,
-        layout: match val.get("layout").unwrap().as_str().unwrap().as_ref() {
+        layout: match val.get("layout").unwrap().as_str().unwrap() {
             "splith" => reply::NodeLayout::SplitH,
             "splitv" => reply::NodeLayout::SplitV,
             "stacked" => reply::NodeLayout::Stacked,

--- a/src/event.rs
+++ b/src/event.rs
@@ -40,7 +40,7 @@ impl FromStr for WorkspaceEventInfo {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let val: json::Value = try!(json::from_str(s));
         Ok(WorkspaceEventInfo {
-            change: match val.get("change").unwrap().as_str().unwrap().as_ref() {
+            change: match val.get("change").unwrap().as_str().unwrap() {
                 "focus" => WorkspaceChange::Focus,
                 "init" => WorkspaceChange::Init,
                 "empty" => WorkspaceChange::Empty,
@@ -81,7 +81,7 @@ impl FromStr for OutputEventInfo {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let val: json::Value = try!(json::from_str(s));
         Ok(OutputEventInfo {
-            change: match val.get("change").unwrap().as_str().unwrap().as_ref() {
+            change: match val.get("change").unwrap().as_str().unwrap() {
                 "unspecified" => OutputChange::Unspecified,
                 other => {
                     warn!(target: "i3ipc", "Unknown OutputChange {}", other);
@@ -126,7 +126,7 @@ impl FromStr for WindowEventInfo {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let val: json::Value = try!(json::from_str(s));
         Ok(WindowEventInfo {
-            change: match val.get("change").unwrap().as_str().unwrap().as_ref() {
+            change: match val.get("change").unwrap().as_str().unwrap() {
                 "new" => WindowChange::New,
                 "close" => WindowChange::Close,
                 "focus" => WindowChange::Focus,
@@ -183,7 +183,7 @@ impl FromStr for BindingEventInfo {
         let val: json::Value = try!(json::from_str(s));
         let bind = val.get("binding").unwrap();
         Ok(BindingEventInfo {
-            change: match val.get("change").unwrap().as_str().unwrap().as_ref() {
+            change: match val.get("change").unwrap().as_str().unwrap() {
                 "run" => BindingChange::Run,
                 other => {
                     warn!(target: "i3ipc", "Unknown BindingChange {}", other);
@@ -202,7 +202,7 @@ impl FromStr for BindingEventInfo {
                     json::Value::Null => None,
                     _ => unreachable!()
                 },
-                input_type: match bind.get("input_type").unwrap().as_str().unwrap().as_ref() {
+                input_type: match bind.get("input_type").unwrap().as_str().unwrap() {
                     "keyboard" => InputType::Keyboard,
                     "mouse" => InputType::Mouse,
                     other => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,8 +57,7 @@ impl Error for EstablishError {
     }
     fn cause(&self) -> Option<&Error> {
         match *self {
-            EstablishError::GetSocketPathError(ref e) => Some(e),
-            EstablishError::SocketError(ref e) => Some(e)
+            EstablishError::GetSocketPathError(ref e) | EstablishError::SocketError(ref e) => Some(e)
         }
     }
 }
@@ -90,8 +89,7 @@ impl Error for MessageError {
     }
     fn cause(&self) -> Option<&Error> {
         match *self {
-            MessageError::Send(ref e) => Some(e),
-            MessageError::Receive(ref e) => Some(e),
+            MessageError::Send(ref e) | MessageError::Receive(ref e) => Some(e),
             MessageError::JsonCouldntParse(ref e) => Some(e),
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -252,7 +252,7 @@ pub struct I3EventListener {
 impl I3EventListener {
     /// Establishes the IPC connection.
     pub fn connect() -> Result<I3EventListener, EstablishError> {
-        return match get_socket_path() {
+        match get_socket_path() {
             Ok(path) => {
                 match UnixStream::connect(path) {
                     Ok(stream) => Ok(I3EventListener { stream: stream }),
@@ -300,7 +300,7 @@ pub struct I3Connection {
 impl I3Connection {
     /// Establishes the IPC connection.
     pub fn connect() -> Result<I3Connection, EstablishError> {
-        return match get_socket_path() {
+        match get_socket_path() {
             Ok(path) => {
                 match UnixStream::connect(path) {
                     Ok(stream) => Ok(I3Connection { stream: stream }),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -115,7 +115,7 @@ fn get_socket_path() -> io::Result<String> {
                   .to_owned())
     } else {
         let prefix = "i3 --getsocketpath didn't return 0";
-        let error_text = if output.stderr.len() > 0 {
+        let error_text = if !output.stderr.is_empty() {
             format!("{}. stderr: {:?}", prefix, output.stderr)
         } else {
             prefix.to_owned()


### PR DESCRIPTION
These five commits each resolve one category of complaints from clippy. None of them should change any functionality or break anything.

There are still two clippy warnings present; one arguably-misleading one about using a function call within `unwrap_or`, and one potentially complicated one about the size difference in the variants of the `Event` enum: `WorkspaceEvent` holds a `WorkspaceEventInfo` struct which is noticeably larger than the other variants.