### PR TITLE
Fix inaccurate error message

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -114,7 +114,7 @@ fn get_socket_path() -> io::Result<String> {
                   .trim_right_matches('\n')
                   .to_owned())
     } else {
-        let prefix = "i3 --getsocketpath didn't return 0";
+        let prefix = "i3 --get-socketpath didn't return 0";
         let error_text = if !output.stderr.is_empty() {
             format!("{}. stderr: {:?}", prefix, output.stderr)
         } else {


### PR DESCRIPTION
This corrects a small typo in the error message shown if asking i3 for its socket path fails.  This is my first pull request; I hope I did everything right.

Got excited that maybe the error message I was seeing in my project wasn't my fault.  Nope! your code was fine; only your error message wasn't.  Time for me to go back to debugging.