### PR TITLE
Update dependencies to their latest versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,10 +7,10 @@ license = "MIT"
 repository = "https://github.com/tmerr/i3ipc-rs"
 
 [dependencies]
-byteorder = "1.1.0"
-log = "0.3.8"
-serde = "1.0.15"
-serde_json = "1.0.3"
+byteorder = "1.2.7"
+log = "0.4.6"
+serde = "1.0.80"
+serde_json = "1.0.32"
 
 [features]
 i3-4-12 = []


### PR DESCRIPTION
Particularily relevant for log, for which the latest version won't be selected automatically. None of the breaking changes from [log 0.4](https://github.com/rust-lang-nursery/log/blob/master/CHANGELOG.md#040---2017-12-24) seem to affect this crate though, so only `Cargo.toml` had to be updated.