### PR TITLE
add fmt check to ci [not ready to merge]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,7 @@ before_script:
   pip install 'travis-cargo<0.2' --user &&
   export PATH=$HOME/.local/bin:$PATH
 script:
-- |
-  travis-cargo build -- --features i3-next &&
-  travis-cargo --only nightly doc -- --features dox
+- ./travis.sh
 env:
   global:
   # don't have special dependencies for nightly build

--- a/travis.sh
+++ b/travis.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -o errexit
+
+travis-cargo build -- --features i3-next
+travis-cargo --only nightly doc -- --features dox
+rustup component add rustfmt
+rustfmt --version
+cargo fmt -- --check


### PR DESCRIPTION
`cargo fmt -- --check` currently fails on `master`. I think we should either

- ensure on travis that `cargo fmt -- --check` passes or
- decide that this project is formatted manually and `rustfmt` isn't used.

I would prefer the first option.