### PR TITLE
Add marks property to Node

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -33,6 +33,15 @@ pub fn build_tree(val: &json::Value) -> reply::Node {
                 .collect(),
             None => vec![],
         },
+        marks: match val.get("marks") {
+            Some(mks) => mks
+                .as_array()
+                .unwrap()
+                .iter()
+                .map(|i| String::from(i.as_str().unwrap()))
+                .collect(),
+            None => vec![],
+        },
         id: val.get("id").unwrap().as_i64().unwrap(),
         name: match val.get("name") {
             Some(n) => match n.as_str() {

--- a/src/reply.rs
+++ b/src/reply.rs
@@ -188,6 +188,9 @@ pub struct Node {
     /// "workspace" or "dockarea".
     pub nodetype: NodeType,
 
+    /// Marks (if any) that have been set on this container.
+    pub marks: Vec<String>,
+
     /// Can be either "normal", "none" or "1pixel", dependending on the container’s border
     /// style.
     pub border: NodeBorder,


### PR DESCRIPTION
When a node has marks set, they will be in a 'marks' key in the JSON node. The key is absent if no marks are set. This isn't documented in the i3-rpc manual, so it's not stable. At the same time i3 changes fairly slowly, so it could be worth adding. 