### PR TITLE
Add Option<pid> field to Node

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -92,6 +92,7 @@ pub fn build_tree(val: &json::Value) -> reply::Node {
         window_properties: build_window_properties(val.get("window_properties")),
         urgent: val.get("urgent").unwrap().as_bool().unwrap(),
         focused: val.get("focused").unwrap().as_bool().unwrap(),
+        pid: val.get("pid").map(|val| val.as_i64().unwrap() as i32),
     }
 }
 

--- a/src/common.rs
+++ b/src/common.rs
@@ -92,6 +92,8 @@ pub fn build_tree(val: &json::Value) -> reply::Node {
         window_properties: build_window_properties(val.get("window_properties")),
         urgent: val.get("urgent").unwrap().as_bool().unwrap(),
         focused: val.get("focused").unwrap().as_bool().unwrap(),
+
+        #[cfg(feature = "sway-1-1")]
         pid: val.get("pid").map(|val| val.as_i64().unwrap() as i32),
     }
 }

--- a/src/reply.rs
+++ b/src/reply.rs
@@ -244,6 +244,7 @@ pub struct Node {
 
     /// The PID of the program running in this container. Appears on Con and FloatingCon
     /// NodeTypes in Swaywm.
+    #[cfg(feature = "sway-1-1")]
     pub pid: Option<i32>,
 }
 

--- a/src/reply.rs
+++ b/src/reply.rs
@@ -241,6 +241,10 @@ pub struct Node {
 
     /// Whether this container is currently focused.
     pub focused: bool,
+
+    /// The PID of the program running in this container. Appears on Con and FloatingCon
+    /// NodeTypes in Swaywm.
+    pub pid: Option<i32>,
 }
 
 /// The reply to the `get_marks` request.


### PR DESCRIPTION
Con and FloatingCon nodes in Swaywm have a pid field specifying the PID of the program running in the container.

edit:
PID field added to Sway in this PR: https://github.com/swaywm/sway/pull/2676