### PR TITLE
Add support for container marks

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -92,6 +92,15 @@ pub fn build_tree(val: &json::Value) -> reply::Node {
         window_properties: build_window_properties(val.get("window_properties")),
         urgent: val.get("urgent").unwrap().as_bool().unwrap(),
         focused: val.get("focused").unwrap().as_bool().unwrap(),
+        marks: match val.get("marks") {
+            Some(xs) => Some(xs
+                .as_array()
+                .unwrap()
+                .iter()
+                .map(|x| x.as_str().unwrap().to_owned())
+                .collect()),
+            None => None,
+        },
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,13 +49,7 @@ pub enum EstablishError {
 }
 
 impl Error for EstablishError {
-    fn description(&self) -> &str {
-        match *self {
-            EstablishError::GetSocketPathError(_) => "Couldn't determine i3's socket path",
-            EstablishError::SocketError(_) => "Found i3's socket path but failed to connect",
-        }
-    }
-    fn cause(&self) -> Option<&dyn Error> {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
         match *self {
             EstablishError::GetSocketPathError(ref e) | EstablishError::SocketError(ref e) => {
                 Some(e)
@@ -66,7 +60,10 @@ impl Error for EstablishError {
 
 impl fmt::Display for EstablishError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
+        write!(f, "{}", match *self {
+            EstablishError::GetSocketPathError(_) => "Couldn't determine i3's socket path",
+            EstablishError::SocketError(_) => "Found i3's socket path but failed to connect",
+        })
     }
 }
 
@@ -82,16 +79,7 @@ pub enum MessageError {
 }
 
 impl Error for MessageError {
-    fn description(&self) -> &str {
-        match *self {
-            MessageError::Send(_) => "Network error while sending message to i3",
-            MessageError::Receive(_) => "Network error while receiving message from i3",
-            MessageError::JsonCouldntParse(_) => {
-                "Got a response from i3 but couldn't parse the JSON"
-            }
-        }
-    }
-    fn cause(&self) -> Option<&dyn Error> {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
         match *self {
             MessageError::Send(ref e) | MessageError::Receive(ref e) => Some(e),
             MessageError::JsonCouldntParse(ref e) => Some(e),
@@ -101,7 +89,13 @@ impl Error for MessageError {
 
 impl fmt::Display for MessageError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
+        write!(f, "{}", match *self {
+            MessageError::Send(_) => "Network error while sending message to i3",
+            MessageError::Receive(_) => "Network error while receiving message from i3",
+            MessageError::JsonCouldntParse(_) => {
+                "Got a response from i3 but couldn't parse the JSON"
+            }
+        })
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -132,7 +132,7 @@ fn get_socket_path() -> io::Result<String> {
 }
 
 trait I3Funcs {
-    fn send_i3_message(&mut self, u32, &str) -> io::Result<()>;
+    fn send_i3_message(&mut self, message_type: u32, payload: &str) -> io::Result<()>;
     fn receive_i3_message(&mut self) -> io::Result<(u32, String)>;
     fn send_receive_i3_message<T: serde::de::DeserializeOwned>(
         &mut self,

--- a/src/reply.rs
+++ b/src/reply.rs
@@ -241,6 +241,9 @@ pub struct Node {
 
     /// Whether this container is currently focused.
     pub focused: bool,
+
+    /// Marks for the container
+    pub marks: Option<Vec<String>>,
 }
 
 /// The reply to the `get_marks` request.


### PR DESCRIPTION
Container marks have been available in i3 since at least 4.12, so they
do not require a feature-gate.

Signed-off-by: Rouven Czerwinski <rouven@czerwinskis.de>