### PR TITLE
Add marks to get_tree

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -75,6 +75,15 @@ pub fn build_tree(val: &json::Value) -> reply::Node {
                 reply::NodeLayout::Unknown
             }
         },
+        marks: match val.get("marks") {
+            Some(mrks) => mrks
+                .as_array()
+                .unwrap()
+                .iter()
+                .map(|m| String::from(m.as_str().unwrap()))
+                .collect(),
+            None => vec![],
+        },
         percent: match *val.get("percent").unwrap() {
             json::Value::Number(ref f) => Some(f.as_f64().unwrap()),
             json::Value::Null => None,

--- a/src/reply.rs
+++ b/src/reply.rs
@@ -199,6 +199,9 @@ pub struct Node {
     /// might be possible in the future, should we add new layouts.
     pub layout: NodeLayout,
 
+    /// A list of the marks applied to this node.
+    pub marks: Vec<String>,
+
     /// The percentage which this container takes in its parent. A value of null means that the
     /// percent property does not make sense for this container, for example for the root
     /// container.


### PR DESCRIPTION
This PR adds the `marks` key to `Node` and `get_tree`. These represent a list of the marks applied to the specific node and have been implemented as a vector of strings (`Vec<String>`).

It looks like `marks` has been supported since before i3wm v4.11, since updates to the existing functionality were mentioned in the [release notes](https://i3wm.org/downloads/RELEASE-NOTES-4.11.txt).