### PR TITLE
Derive Serialize, Deserialize on data structures

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,8 +9,8 @@ repository = "https://github.com/tmerr/i3ipc-rs"
 [dependencies]
 byteorder = "1.2.7"
 log = "0.4.6"
-serde = "1.0.80"
-serde_json = "1.0.32"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = { version = "1.0" }
 
 [features]
 i3-4-12 = []

--- a/src/event.rs
+++ b/src/event.rs
@@ -2,6 +2,7 @@
 
 use common;
 use reply;
+use serde::{Deserialize, Serialize};
 use serde_json as json;
 use std::str::FromStr;
 
@@ -23,7 +24,7 @@ pub enum Event {
 }
 
 /// Data for `WorkspaceEvent`.
-#[derive(Debug)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct WorkspaceEventInfo {
     /// The type of change.
     pub change: WorkspaceChange,
@@ -70,7 +71,7 @@ impl FromStr for WorkspaceEventInfo {
 }
 
 /// Data for `OutputEvent`.
-#[derive(Debug)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct OutputEventInfo {
     /// The type of change.
     pub change: OutputChange,
@@ -93,7 +94,7 @@ impl FromStr for OutputEventInfo {
 }
 
 /// Data for `ModeEvent`.
-#[derive(Debug)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct ModeEventInfo {
     /// The name of current mode in use. It is the same as specified in config when creating a
     /// mode. The default mode is simply named default.
@@ -111,7 +112,7 @@ impl FromStr for ModeEventInfo {
 }
 
 /// Data for `WindowEvent`.
-#[derive(Debug)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct WindowEventInfo {
     /// Indicates the type of change
     pub change: WindowChange,
@@ -150,7 +151,7 @@ impl FromStr for WindowEventInfo {
 }
 
 /// Data for `BarConfigEvent`.
-#[derive(Debug)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct BarConfigEventInfo {
     /// The new i3 bar configuration.
     pub bar_config: reply::BarConfig,
@@ -169,7 +170,7 @@ impl FromStr for BarConfigEventInfo {
 /// Data for `BindingEvent`.
 ///
 /// Reports on the details of a binding that ran a command because of user input.
-#[derive(Debug)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct BindingEventInfo {
     /// Indicates what sort of binding event was triggered (right now it will always be "run" but
     /// that may be expanded in the future).
@@ -220,7 +221,7 @@ impl FromStr for BindingEventInfo {
 }
 
 /// Data for `ShutdownEvent`.
-#[derive(Debug)]
+#[derive(Debug, Deserialize, Serialize)]
 #[cfg(feature = "i3-4-14")]
 #[cfg_attr(feature = "dox", doc(cfg(feature = "i3-4-14")))]
 pub struct ShutdownEventInfo {
@@ -247,8 +248,10 @@ impl FromStr for ShutdownEventInfo {
 
 /// Less important types
 pub mod inner {
+    use serde::{Deserialize, Serialize};
+
     /// The kind of workspace change.
-    #[derive(Debug, PartialEq)]
+    #[derive(Debug, Deserialize, Serialize, PartialEq)]
     pub enum WorkspaceChange {
         Focus,
         Init,
@@ -263,7 +266,7 @@ pub mod inner {
     }
 
     /// The kind of output change.
-    #[derive(Debug, PartialEq)]
+    #[derive(Debug, Deserialize, Serialize, PartialEq)]
     pub enum OutputChange {
         Unspecified,
         /// An OutputChange we don't support yet.
@@ -271,7 +274,7 @@ pub mod inner {
     }
 
     /// The kind of window change.
-    #[derive(Debug, PartialEq)]
+    #[derive(Debug, Deserialize, Serialize, PartialEq)]
     pub enum WindowChange {
         /// The window has become managed by i3.
         New,
@@ -300,7 +303,7 @@ pub mod inner {
     }
 
     /// Either keyboard or mouse.
-    #[derive(Debug, PartialEq)]
+    #[derive(Debug, Deserialize, Serialize, PartialEq)]
     pub enum InputType {
         Keyboard,
         Mouse,
@@ -309,7 +312,7 @@ pub mod inner {
     }
 
     /// Contains details about the binding that was run.
-    #[derive(Debug, PartialEq)]
+    #[derive(Debug, Deserialize, Serialize, PartialEq)]
     pub struct Binding {
         /// The i3 command that is configured to run for this binding.
         pub command: String,
@@ -331,7 +334,7 @@ pub mod inner {
     }
 
     /// The kind of binding change.
-    #[derive(Debug, PartialEq)]
+    #[derive(Debug, Deserialize, Serialize, PartialEq)]
     pub enum BindingChange {
         Run,
         /// A BindingChange we don't support yet.
@@ -339,7 +342,7 @@ pub mod inner {
     }
 
     /// The kind of shutdown change.
-    #[derive(Debug, PartialEq)]
+    #[derive(Debug, Deserialize, Serialize, PartialEq)]
     #[cfg(feature = "i3-4-14")]
     #[cfg_attr(feature = "dox", doc(cfg(feature = "i3-4-14")))]
     pub enum ShutdownChange {

--- a/src/reply.rs
+++ b/src/reply.rs
@@ -1,9 +1,10 @@
 //! Abstractions for the replies passed back from i3.
 
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 /// The outcome of a single command.
-#[derive(Debug)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct CommandOutcome {
     /// Whether the command was successful.
     pub success: bool,
@@ -12,14 +13,14 @@ pub struct CommandOutcome {
 }
 
 /// The reply to the `command` request.
-#[derive(Debug)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct Command {
     /// A list of `CommandOutcome` structs; one for each command that was parsed.
     pub outcomes: Vec<CommandOutcome>,
 }
 
 /// A single workspace.
-#[derive(Debug)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct Workspace {
     /// The logical number of the workspace. Corresponds to the command to switch to this
     /// workspace. For named workspaces, this will be -1.
@@ -42,14 +43,14 @@ pub struct Workspace {
 }
 
 /// The reply to the `get_workspaces` request.
-#[derive(Debug)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct Workspaces {
     /// A list of workspaces.
     pub workspaces: Vec<Workspace>,
 }
 
 /// The reply to the `subscribe` request.
-#[derive(Debug)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct Subscribe {
     /// Indicates whether the subscription was successful (the default) or whether a JSON
     /// parse error occurred.
@@ -57,7 +58,7 @@ pub struct Subscribe {
 }
 
 #[cfg(feature = "sway-1-1")]
-#[derive(Debug)]
+#[derive(Debug, Deserialize, Serialize)]
 /// A mode for sway
 pub struct Mode {
     pub width: i32,
@@ -66,7 +67,7 @@ pub struct Mode {
 }
 
 /// A single output (display)
-#[derive(Debug)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct Output {
     /// The name of this output (as seen in xrandr).
     pub name: String,
@@ -110,13 +111,13 @@ pub struct Output {
 }
 
 /// The reply to the `get_outputs` request.
-#[derive(Debug)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct Outputs {
     /// A list of outputs (displays)
     pub outputs: Vec<Output>,
 }
 
-#[derive(Eq, PartialEq, Debug, Hash, Clone)]
+#[derive(Eq, PartialEq, Debug, Deserialize, Serialize, Hash, Clone)]
 pub enum WindowProperty {
     Title,
     Instance,
@@ -125,7 +126,7 @@ pub enum WindowProperty {
     TransientFor,
 }
 
-#[derive(Eq, PartialEq, Debug, Clone)]
+#[derive(Eq, PartialEq, Debug, Deserialize, Serialize, Clone)]
 pub enum NodeType {
     Root,
     Output,
@@ -137,7 +138,7 @@ pub enum NodeType {
     Unknown,
 }
 
-#[derive(Eq, PartialEq, Debug, Clone)]
+#[derive(Eq, PartialEq, Debug, Deserialize, Serialize, Clone)]
 pub enum NodeBorder {
     Normal,
     None,
@@ -146,7 +147,7 @@ pub enum NodeBorder {
     Unknown,
 }
 
-#[derive(Eq, PartialEq, Debug, Clone)]
+#[derive(Eq, PartialEq, Debug, Deserialize, Serialize, Clone)]
 pub enum NodeLayout {
     SplitH,
     SplitV,
@@ -159,7 +160,7 @@ pub enum NodeLayout {
 }
 
 /// The reply to the `get_tree` request.
-#[derive(Debug, Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct Node {
     /// List of child node IDs (see `nodes`, `floating_nodes` and `id`) in focus order. Traversing
     /// the tree by following the first entry in this array will result in eventually reaching the
@@ -248,7 +249,7 @@ pub struct Node {
 /// Consists of a single vector of strings for each container that has a mark. A mark can only
 /// be set on one container, so the vector is unique. The order of that vector is undefined. If
 /// no window has a mark the response will be an empty vector.
-#[derive(Debug)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct Marks {
     pub marks: Vec<String>,
 }
@@ -257,13 +258,13 @@ pub struct Marks {
 ///
 /// This can be used by third-party workspace bars (especially i3bar, but others are free to
 /// implement compatible alternatives) to get the bar block configuration from i3.
-#[derive(Debug)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct BarIds {
     /// A vector of configured bar IDs.
     pub ids: Vec<String>,
 }
 
-#[derive(Hash, Eq, PartialEq, Debug)]
+#[derive(Hash, Eq, PartialEq, Debug, Deserialize, Serialize)]
 pub enum ColorableBarPart {
     /// Background color of the bar.
     Background,
@@ -354,7 +355,7 @@ pub enum ColorableBarPart {
 ///
 /// This can be used by third-party workspace bars (especially i3bar, but others are free to
 /// implement compatible alternatives) to get the bar block configuration from i3.
-#[derive(Debug)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct BarConfig {
     /// The ID for this bar. Included in case you request multiple configurations and want to
     /// differentiate the different replies.
@@ -389,7 +390,7 @@ pub struct BarConfig {
 }
 
 /// The reply to the `get_version` request.
-#[derive(Debug)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct Version {
     /// The major version of i3, such as 4.
     pub major: i32,
@@ -416,7 +417,7 @@ pub struct Version {
 /// The reply to the `get_binding_modes` request.
 #[cfg(feature = "i3-4-13")]
 #[cfg_attr(feature = "dox", doc(cfg(feature = "i3-4-13")))]
-#[derive(Debug)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct BindingModes {
     /// A vector of all currently configured binding modes.
     pub modes: Vec<String>,
@@ -425,7 +426,7 @@ pub struct BindingModes {
 /// The reply to the `get_config` request.
 #[cfg(feature = "i3-4-14")]
 #[cfg_attr(feature = "dox", doc(cfg(feature = "i3-4-14")))]
-#[derive(Debug)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct Config {
     /// A string containing the config file as loaded by i3 most recently.
     pub config: String,


### PR DESCRIPTION
Hi Trevor,

I was writing a small program using your crate and found that I could not easily "serde" the event data to JSON. There are ways around this but that would be a lot of work - it would be much more convenient for me if the `Serialize` and `Deserialize` traits were already on the types in your crate.

Turns out the Rust API guidelines [recommend](https://rust-lang.github.io/api-guidelines/interoperability.html) that authors implement the serde `Serialize` and `Deserialize` traits on all data structures, presumably for this sort of reason.

I went ahead and derived `Serialize` and `Deserialize` on all data structures I could find, given the fact that you use `serde` anyway. One notable exception is the `Event` enum, it didn't seem like enough of a data structure to me.

Also (this is in the same link above) they recommend a specific way to pull in `serde` and `serde_json`, I went ahead and put that in Cargo.toml. All unit tests still pass.

Don't hesitate to let me know if you'd like me to change anything in this PR, I'd be happy to. Thanks for your time!

Toon