### PR TITLE
Added find_child as a method on the Node struct

### DIFF
--- a/src/reply.rs
+++ b/src/reply.rs
@@ -243,6 +243,28 @@ pub struct Node {
     pub focused: bool,
 }
 
+impl Node {
+    pub fn find_child(&self, f: fn(&Node) -> bool) -> Option<&Node> {
+
+        if f(&self) {
+            return Some(self)
+        }
+        for m in self.nodes.iter() {
+            match m.find_child(f) {
+                Some(o) => return Some(o),
+                None => {}
+            }
+        }
+        for m in self.floating_nodes.iter() {
+            match m.find_child(f) {
+                Some(o) => return Some(o),
+                None => {}
+            }
+        }
+        None
+    }
+}
+
 /// The reply to the `get_marks` request.
 ///
 /// Consists of a single vector of strings for each container that has a mark. A mark can only

--- a/src/reply.rs
+++ b/src/reply.rs
@@ -245,7 +245,6 @@ pub struct Node {
 
 impl Node {
     pub fn find_child(&self, f: fn(&Node) -> bool) -> Option<&Node> {
-
         if f(&self) {
             return Some(self)
         }


### PR DESCRIPTION
Simple way to find a child node, either in nodes or floating_nodes based on a predicate. 

This pretty much just mirrors what is done here https://github.com/i3/go-i3/blob/36e6ec85cc5a/tree.go#L92 in the go version of this library. This is a pretty useful thing to have when you are trying to find a specific node in the tree. 