### PR TITLE
Fix window properties

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -110,9 +110,10 @@ pub fn build_window_properties(
                     "window_role" => Some(reply::WindowProperty::WindowRole),
                     "title" => Some(reply::WindowProperty::Title),
                     "transient_for" => Some(reply::WindowProperty::TransientFor),
+                    "machine" => Some(reply::WindowProperty::Machine),
                     other => {
                         warn!(target: "i3ipc", "Unknown WindowProperty {}", other);
-                        return None;
+                        None
                     }
                 };
                 if let Some(window_property) = window_property {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,7 +66,7 @@ impl Error for EstablishError {
 
 impl fmt::Display for EstablishError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
+        write!(f, "{}", self.to_string())
     }
 }
 
@@ -101,7 +101,7 @@ impl Error for MessageError {
 
 impl fmt::Display for MessageError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
+        write!(f, "{}", self.to_string())
     }
 }
 
@@ -132,7 +132,7 @@ fn get_socket_path() -> io::Result<String> {
 }
 
 trait I3Funcs {
-    fn send_i3_message(&mut self, u32, &str) -> io::Result<()>;
+    fn send_i3_message(&mut self, message_type: u32, payload: &str) -> io::Result<()>;
     fn receive_i3_message(&mut self) -> io::Result<(u32, String)>;
     fn send_receive_i3_message<T: serde::de::DeserializeOwned>(
         &mut self,

--- a/src/reply.rs
+++ b/src/reply.rs
@@ -123,6 +123,7 @@ pub enum WindowProperty {
     Class,
     WindowRole,
     TransientFor,
+    Machine,
 }
 
 #[derive(Eq, PartialEq, Debug, Clone)]


### PR DESCRIPTION
Getting the window_properties on nodes in the tree results in all `None` (on i3 version 4.20). This is caused by an unknown window_property `"machine"`.

```rust
let mut i3 = I3Connection::connect().unwrap();
let tree = i3.get_tree().unwrap();
let node = find_focused(&tree).unwrap();
println!("{:?}", node.window_properties);
```

This PR fixes the issue of unknown window_properties resulting in an empty HashMap. And it also adds the `"machine"` window_property.

I also fixed some deprecation warnings (on rust 1.56.1).