### PR TITLE
Fix unknown window props

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -199,7 +199,7 @@ pub fn build_bar_config(j: &json::Value) -> reply::BarConfig {
 
 #[cfg(feature = "sway-1-1")]
 pub fn build_modes(j: &json::Value) -> Vec<reply::Mode> {
-    let mut res: Vec<reply::Mode>= Vec::new();
+    let mut res: Vec<reply::Mode> = Vec::new();
     for mode in j.as_array().unwrap() {
         res.push(build_mode(mode))
     }
@@ -214,6 +214,6 @@ pub fn build_mode(jmode: &json::Value) -> reply::Mode {
     reply::Mode {
         width: width,
         height: height,
-        refresh: refresh
+        refresh: refresh,
     }
 }

--- a/src/common.rs
+++ b/src/common.rs
@@ -110,6 +110,7 @@ pub fn build_window_properties(
                     "window_role" => Some(reply::WindowProperty::WindowRole),
                     "title" => Some(reply::WindowProperty::Title),
                     "transient_for" => Some(reply::WindowProperty::TransientFor),
+                    "machine" => Some(reply::WindowProperty::Machine),
                     other => {
                         warn!(target: "i3ipc", "Unknown WindowProperty {}", other);
                         return None;

--- a/src/common.rs
+++ b/src/common.rs
@@ -111,6 +111,7 @@ pub fn build_window_properties(
                     "title" => Some(reply::WindowProperty::Title),
                     "transient_for" => Some(reply::WindowProperty::TransientFor),
                     "machine" => Some(reply::WindowProperty::Machine),
+                    "mark" => Some(reply::WindowProperty::Mark),
                     other => {
                         warn!(target: "i3ipc", "Unknown WindowProperty {}", other);
                         None

--- a/src/common.rs
+++ b/src/common.rs
@@ -113,7 +113,7 @@ pub fn build_window_properties(
                     "machine" => Some(reply::WindowProperty::Machine),
                     other => {
                         warn!(target: "i3ipc", "Unknown WindowProperty {}", other);
-                        return None;
+                        None
                     }
                 };
                 if let Some(window_property) = window_property {

--- a/src/reply.rs
+++ b/src/reply.rs
@@ -123,6 +123,7 @@ pub enum WindowProperty {
     Class,
     WindowRole,
     TransientFor,
+    Machine,
 }
 
 #[derive(Eq, PartialEq, Debug, Clone)]

--- a/src/reply.rs
+++ b/src/reply.rs
@@ -124,6 +124,7 @@ pub enum WindowProperty {
     WindowRole,
     TransientFor,
     Machine,
+    Mark,
 }
 
 #[derive(Eq, PartialEq, Debug, Clone)]


### PR DESCRIPTION
Issues fixed:
 1. `build_window_properties()` returned None in case some unknown property was found.
 2. Added support for window props "machine" and "mark"